### PR TITLE
feat: FP-16 Introduce github actions, setup rubocop workflow

### DIFF
--- a/.github/workflows/run-rubocop-check.yml
+++ b/.github/workflows/run-rubocop-check.yml
@@ -5,12 +5,16 @@ jobs:
   run-rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Set up Ruby
-        uses: ruby/setup-ruby@359bebbc29cbe6c87da6bc9ea3bc930432750108
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1.2'
+
       - name: Install dependencies
         run: bundle install
+
       - name: Run rubocop
         run: bundle exec rubocop


### PR DESCRIPTION
### Purpose
As we are using rubocop adding it to a pipeline to be ran on each push makes sense so that we won't merge code that violates the styling we have set with rubocop. GH actions will also bring additional capabilities like running tests after we add rspec to the codebase. 